### PR TITLE
Fix issue where dbpath used by a created DataStore was improperly read.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -40,8 +40,9 @@ NeDBCollection.prototype.__proto__ = MongooseCollection.prototype;
 
 NeDBCollection.prototype.onOpen = function() {
   var _this = this;
+  var dbpath = _this.conn.options.db && _this.conn.options.db.dbpath ? _this.conn.options.db.dbpath : '.';
 
-  var collection = new DataStore({ filename: (_this.conn.options.dbpath || '.') + '/' + _this.name + '.db' });
+  var collection = new DataStore({ filename: dbpath + '/' + _this.name + '.db' });
 
   collection.loadDatabase(function (err) {
     if (err) {


### PR DESCRIPTION
Mongoose passes `connection.options.db` to the underlying driver instance (see http://mongoosejs.com/docs/connections.html).
The fix consists in reading `dbpath` from `connection.options.db` instead of `connection.options`.